### PR TITLE
Mqshaw documentation changes

### DIFF
--- a/SmartTally Server/MyTallyServer Guide.md
+++ b/SmartTally Server/MyTallyServer Guide.md
@@ -33,5 +33,5 @@ This server has been written using Python 3, you can download the latest Python 
 
 ---
 ### Revision History
-**2021-05-11** : First release
+**2021-05-11** : First release<br>
 **2021-05-17** : Minor documentation fix

--- a/libraries/M5Atom/utility/MPU6886.cpp
+++ b/libraries/M5Atom/utility/MPU6886.cpp
@@ -127,7 +127,7 @@ void MPU6886::getTempAdc(int16_t *t){
 
 
 
-//!俯仰，航向，横滚：pitch，yaw，roll，指三维空间中飞行器的旋转状态。(Refers to the rotation state of the aircraft in three-dimensional space. Pitch, heading, roll)
+//!俯仰，航向，横滚：pitch，yaw，roll，指三维空间中飞行器的旋转状态。
 void MPU6886::getAhrsData(float *pitch,float *roll,float *yaw){
 
   float accX = 0; 
@@ -144,32 +144,6 @@ void MPU6886::getAhrsData(float *pitch,float *roll,float *yaw){
   
   MahonyAHRSupdateIMU(gyroX * DEG_TO_RAD, gyroY * DEG_TO_RAD, gyroZ * DEG_TO_RAD, accX, accY, accZ,pitch,roll,yaw);
 
-}
-
-void MPU6886::getAttitude(double *pitch, double *roll)
-{
-    float accX = 0;
-    float accY = 0;
-    float accZ = 0;
-
-    float gyroX = 0;
-    float gyroY = 0;
-    float gyroZ = 0;
-
-    getGyroData(&gyroX, &gyroY, &gyroZ);
-    getAccelData(&accX, &accY, &accZ);
-
-    if ((accX < 1) && (accX > -1))
-    {
-        *pitch = asin(-accX) * 57.295;
-    }
-    if (accZ != 0)
-    {
-        *roll = atan(accY / accZ) * 57.295;
-    }
-
-    ( *pitch ) = _alpha * ( *pitch ) + (1 - _alpha) * _last_theta;
-    ( *roll ) = _alpha * ( *roll ) + (1 - _alpha) * _last_phi;
 }
 
 void MPU6886::getGres(){
@@ -218,7 +192,7 @@ void MPU6886::getAres(){
  
 void MPU6886::SetGyroFsr(Gscale scale)
 {
-    //return IIC_Write_Byte(MPU_GYRO_CFG_REG,scale<<3);//设置陀螺仪满量程范围 (Set the full scale range of the gyroscope)
+    //return IIC_Write_Byte(MPU_GYRO_CFG_REG,scale<<3);//设置陀螺仪满量程范围
     unsigned char regdata;	
     regdata = (scale<<3);
     I2C_Write_NBytes(MPU6886_ADDRESS, MPU6886_GYRO_CONFIG, 1, &regdata);

--- a/libraries/libraries_README.md
+++ b/libraries/libraries_README.md
@@ -17,8 +17,9 @@ But even if you do that, you'll still have to rename the `LED_DisPlay.h` and `LE
 To use the modified libraries:
 
 1. Navigate to your Arduino M5Atom libraries directory.
-I'm not certain where this is kept on all platforms or where it was placed during your install. Searching for a folder named M5Atom should turn it up.<br><br>On macOS the default location is:<br>  
-`/Users/*YOUR_USER_NAME*/Documents/Arduino/libraries/M5Atom`<br><br>Inside that folder:
+I'm not certain where this is kept on all platforms or where it was placed during your install. Searching for a folder named M5Atom should turn it up.<br><br>On macOS the default location is:<br>
+`/Users/*YOUR_USER_NAME*/Documents/Arduino/libraries/M5Atom`<br><br>On Windows the default location is:<br>
+`C:\Users\*YOUR_USER_NAME*\Documents\Arduino\libraries\M5Atom`<br><br>Inside that folder:
 
 1. Rename the file `M5Atom.h` to something like `M5Atom.h.orig`
 1. Copy the modified `M5Atom.h` file from this repository into the `Arduino/libraries/M5Atom` folder.
@@ -29,8 +30,7 @@ I'm not certain where this is kept on all platforms or where it was placed durin
 
 &mdash; Note &mdash;<br>You will have to repeat these steps whenever M5Stack updates their <br>M5Atom libraries as their new version will overwrite these modified files.|
 :---:
-
----  
+<br>
 
 ## Improved Preferences Library
 After doing a deep dive into the Espressif ESP 32 IDF NVS storage methods and comparing their documentation to the Arduino ESP32 library, I modified the *Preferences.cpp* file to ensure changes made to the NVS when using certain Arduino *Preferences* function calls were committed to NVS. Those changes are documented in the modified *Preferences.h* file here.
@@ -39,11 +39,13 @@ While not essential for the STAC sketch to compile, I do believe these modified 
 
 ### To use this library
 1. Navigate to your Arduino ESP32 folder.<br>
-I'm not certain where this is kept on all platforms or where it was placed during your install. Searching for a file named *Preferences.cpp* should turn it up.<br><br>On macOS the default location is:<br><br>
-`/Users/*YOUR_USER_NAME*/Library/Arduino15/packages/esp32/hardware/esp32/1.0.6/libraries/Preferences/src`  
+I'm not certain where this is kept on all platforms or where it was placed during your install. Searching for a file named *Preferences.cpp* should turn it up.<br><br>On macOS the default location is:<br>
+`/Users/*YOUR_USER_NAME*/Library/Arduino15/packages/esp32/hardware/esp32/1.0.6/libraries/Preferences/src`<br><br>On Windows the default location is:<br>
+`c:\Users\*YOUR_USER_NAME*\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.6\libraries\Preferences\src`<br>
 
 |&mdash; Note &mdash;<br>As newer versions of the ESP32 Arduino libraries are released,the location will change to reflect the version number of those libraries.<br>Thus, in the path above, you may need to replace *1.0.6* with the current version number.|
 :--:  
+<br>
 
 Inside the *src* folder:
 
@@ -52,7 +54,6 @@ Inside the *src* folder:
 
 &mdash; Note &mdash;<br>You will have to repeat these steps whenever the Arduino ESP32 <br>libraries are updated as the new version will overwrite this modified file.|
 :--:
-
+<br>
 A request has been submitted to the fantastic Arduino ESP32 team to incorporate these changes into the official release.
 
----

--- a/libraries/libraries_README.md
+++ b/libraries/libraries_README.md
@@ -41,7 +41,7 @@ While not essential for the STAC sketch to compile, I do believe these modified 
 1. Navigate to your Arduino ESP32 folder.<br>
 I'm not certain where this is kept on all platforms or where it was placed during your install. Searching for a file named *Preferences.cpp* should turn it up.<br><br>On macOS the default location is:<br>
 `/Users/*YOUR_USER_NAME*/Library/Arduino15/packages/esp32/hardware/esp32/1.0.6/libraries/Preferences/src`<br><br>On Windows the default location is:<br>
-`c:\Users\*YOUR_USER_NAME*\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.6\libraries\Preferences\src`<br>
+`C:\Users\*YOUR_USER_NAME*\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.6\libraries\Preferences\src`<br>
 
 |&mdash; Note &mdash;<br>As newer versions of the ESP32 Arduino libraries are released,the location will change to reflect the version number of those libraries.<br>Thus, in the path above, you may need to replace *1.0.6* with the current version number.|
 :--:  

--- a/libraries/libraries_README.md
+++ b/libraries/libraries_README.md
@@ -8,6 +8,7 @@ So, I modified the following files to correct this oversight (and tweak a few ot
 * `M5Atom.h`
 * `utility/LED_DisPlay.h`
 * `utility/LED_DisPlay.cpp`
+* `utility/MPU6886.cpp`
 
 To get the STAC sketch to compile, you'll have to replace the files provided by M5Stack with these modified versions. Or, in the STAC sketch, replace every call to `M5.dis.fillpix();` with your own routine.
 
@@ -26,7 +27,8 @@ I'm not certain where this is kept on all platforms or where it was placed durin
 1. Open the `utility` folder that is inside the `Arduino/libraries/M5Atom` folder.
 1. Rename the file `LED_DisPlay.h` to something like `LED_DisPlay.h.orig`
 1. Rename the file `LED_DisPlay.cpp` to something like `LED_Display.cpp.orig`
-1. From the `utility` folder in this repository, copy the modified `LED_Display.h` and `LED_Display.cpp` files into the `Arduino/libraries/M5Atom/utility` folder.
+1. Rename the file `MPU6886.cpp` to something like `MPU6886.cpp.orig`
+1. From the `utility` folder in this repository, copy the modified `LED_Display.h`, `LED_Display.cpp` and `MPU6886.cpp` files into the `Arduino/libraries/M5Atom/utility` folder.
 
 &mdash; Note &mdash;<br>You will have to repeat these steps whenever M5Stack updates their <br>M5Atom libraries as their new version will overwrite these modified files.|
 :---:


### PR DESCRIPTION
Hi Rob,

This is the merge request to bring in some documentation changes.  

The MPU6886.cpp change is probably due to a different base version that we are using with the underlying library, I think that the change can be ignored by including the header file in addition to the c file, that way we would always ensure that the function declarations match the header.

I responded earlier to your email about my experiences with STAC 1.9 at church tonight.

Best,
Mark
